### PR TITLE
Made a failure! ...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,9 @@ remoteTypes.each { type ->
 				}
 			
 				//Only put swagger .jars into .war (without transitions)
-				sourceSets.main.runtimeClasspath = files([configurations.remoteRuntime])
+				sourceSets.main.runtimeClasspath -= files([configurations.testCompile])
+				sourceSets.main.runtimeClasspath -= files([configurations.compile])
+				sourceSets.main.runtimeClasspath += files([configurations.remoteRuntime])
 				println ":compileJava"
 				compileJava.execute()
 				println ":processResources"


### PR DESCRIPTION
You are not allowed to overwrite whole sourceSets.main.RuntimeClasspath as the new set(and so the .war) will not contain any classfiles!

This hotfix will only let all classes and the necessary lib(swagger .jars; not transitiv) into the .war.
